### PR TITLE
Comet ml key

### DIFF
--- a/deepprofiler/__main__.py
+++ b/deepprofiler/__main__.py
@@ -33,9 +33,12 @@ import deepprofiler.download.normalize_bbbc021_metadata
 @click.option("--exp", default="results",
               help="Name of experiment",
               type=click.STRING)
+@click.option("--cometml_key", default=None,
+              help="Path to file with comet.ml API key",
+              type=click.STRING)
 
 @click.pass_context
-def cli(context, root, config, exp, cores, gpu):
+def cli(context, root, config, exp, cores, gpu, cometml_key):
     dirs = {
         "root": root,
         "locations": root + "/inputs/locations/",  # TODO: use os.path.join()
@@ -81,6 +84,11 @@ def cli(context, root, config, exp, cores, gpu):
         params["experiment_name"] = exp
         params["paths"]["index"] = params["paths"]["metadata"] + "/index.csv"
         context.obj["config"] = params
+        if cometml_key:
+            with open(cometml_key, "r") as f:
+                cometml_params = json.load(f)
+                context.obj["config"]["train"]["comet_ml"]["api_key"] = cometml_params["api_key"]
+                context.obj["config"]["train"]["comet_ml"]["project_name"] = cometml_params["project_name"]
     elif context.invoked_subcommand != 'setup':
         raise Exception("Config does not exists; make sure that the file exists in /inputs/config/")
 

--- a/deepprofiler/__main__.py
+++ b/deepprofiler/__main__.py
@@ -85,7 +85,7 @@ def cli(context, root, config, exp, cores, gpu, cometml_key):
         params["paths"]["index"] = params["paths"]["metadata"] + "/index.csv"
         context.obj["config"] = params
         if cometml_key:
-            with open(cometml_key, "r") as f:
+            with open(os.path.join(dirs["config"], cometml_key), "r") as f:
                 cometml_params = json.load(f)
                 context.obj["config"]["train"]["comet_ml"] = {}
                 context.obj["config"]["train"]["comet_ml"]["api_key"] = cometml_params["api_key"]

--- a/deepprofiler/__main__.py
+++ b/deepprofiler/__main__.py
@@ -87,6 +87,7 @@ def cli(context, root, config, exp, cores, gpu, cometml_key):
         if cometml_key:
             with open(cometml_key, "r") as f:
                 cometml_params = json.load(f)
+                context.obj["config"]["train"]["comet_ml"] = {}
                 context.obj["config"]["train"]["comet_ml"]["api_key"] = cometml_params["api_key"]
                 context.obj["config"]["train"]["comet_ml"]["project_name"] = cometml_params["project_name"]
     elif context.invoked_subcommand != 'setup':

--- a/deepprofiler/learning/model.py
+++ b/deepprofiler/learning/model.py
@@ -30,8 +30,6 @@ class DeepProfilerModel(abc.ABC):
         self.train_crop_generator = crop_generator(config, dset)
         self.val_crop_generator = val_crop_generator(config, dset)
         self.random_seed = None
-        if "comet_ml" not in config["train"].keys():
-            self.config["train"]["comet_ml"]["track"] = False
 
     def seed(self, seed):
         self.random_seed = seed
@@ -108,7 +106,7 @@ def check_feature_model(dpmodel):
 
 
 def setup_comet_ml(dpmodel):
-    if dpmodel.config["train"]["comet_ml"]["track"]:
+    if dpmodel.config["train"]["comet_ml"]:
         experiment = comet_ml.Experiment(
             api_key=dpmodel.config["train"]["comet_ml"]["api_key"],
             project_name=dpmodel.config["train"]["comet_ml"]["project_name"]
@@ -179,7 +177,7 @@ def setup_params(dpmodel, experiment):
     steps = dpmodel.dset.steps_per_epoch
     lr_schedule_epochs = []
     lr_schedule_lr = []
-    if dpmodel.config["train"]["comet_ml"]["track"]:
+    if dpmodel.config["train"]["comet_ml"]:
         params = dpmodel.config["train"]["model"]["params"]
         experiment.log_others(params)
     if "lr_schedule" in dpmodel.config["train"]["model"]:

--- a/deepprofiler/learning/model.py
+++ b/deepprofiler/learning/model.py
@@ -106,7 +106,7 @@ def check_feature_model(dpmodel):
 
 
 def setup_comet_ml(dpmodel):
-    if dpmodel.config["train"]["comet_ml"]:
+    if 'comet_ml' in dpmodel.config["train"].keys():
         experiment = comet_ml.Experiment(
             api_key=dpmodel.config["train"]["comet_ml"]["api_key"],
             project_name=dpmodel.config["train"]["comet_ml"]["project_name"]
@@ -177,7 +177,7 @@ def setup_params(dpmodel, experiment):
     steps = dpmodel.dset.steps_per_epoch
     lr_schedule_epochs = []
     lr_schedule_lr = []
-    if dpmodel.config["train"]["comet_ml"]:
+    if 'comet_ml' in dpmodel.config["train"].keys():
         params = dpmodel.config["train"]["model"]["params"]
         experiment.log_others(params)
     if "lr_schedule" in dpmodel.config["train"]["model"]:

--- a/tests/files/config/test.json
+++ b/tests/files/config/test.json
@@ -62,11 +62,6 @@
             "workers": 2,
             "alpha": 0.2
         },
-        "comet_ml": {
-            "track": false,
-            "api_key": "",
-            "project_name": "test"
-          },
           "validation": {
               "top_k": 1,
               "batch_size": 2,


### PR DESCRIPTION
CometML config now can be stored in a separate JSON file.
Also, CometML keys can be stored in the old manner (in the config file).
Provide full path to the JSON file with `--cometml_key` command line param.
Format of the JSON file:
```
{
    "api_key": "API_KEY",
    "project_name": "project-name"
}

```
I have removed the `comet_ml` section from the test config (it is not default part of the config anymore).
@jccaicedo We should update wiki to keep it up with this change. 