### PR TITLE
Issues/222

### DIFF
--- a/deepprofiler/dataset/image_dataset.py
+++ b/deepprofiler/dataset/image_dataset.py
@@ -231,7 +231,7 @@ def read_dataset(config):
         dset.add_target(new_target)
 
     # Activate outlines for masking if needed
-    if config["train"]["sampling"]["mask_objects"]:
+    if config["dataset"]["locations"]["mask_objects"]:
         dset.outlines = outlines
 
     dset.prepare_training_locations()

--- a/deepprofiler/imaging/boxes.py
+++ b/deepprofiler/imaging/boxes.py
@@ -54,7 +54,7 @@ def prepare_boxes(batch, config):
             all_targets[i].append(image_targets[index][i] * np.ones((len(locations)), np.int32))
         # Identify object mask for each crop
         masks = np.zeros(len(locations), np.int32)
-        if config["train"]["sampling"]["mask_objects"]:
+        if config["dataset"]["locations"]["mask_objects"]:
             i = 0
             for lkey in locations.index:
                 y = int(locations.loc[lkey, y_key])

--- a/deepprofiler/imaging/boxes.py
+++ b/deepprofiler/imaging/boxes.py
@@ -3,12 +3,23 @@ import os
 import numpy as np
 import pandas as pd
 
+X_KEY = "Nuclei_Location_Center_X"
+Y_KEY = "Nuclei_Location_Center_Y"
 
 #################################################
 ## BOUNDING BOX HANDLING
 #################################################
 
 def get_locations(image_key, config, random_sample=None, seed=None):
+    if config["dataset"]["locations"]["mode"] == "single_cells":
+        return get_single_cell_locations(image_key, config, random_sample, seed)
+    elif config["dataset"]["locations"]["mode"] == "full_image":
+        return get_full_image_locations(image_key, config, random_sample, seed)
+    else:
+        return None
+
+
+def get_single_cell_locations(image_key, config, random_sample=None, seed=None):
     keys = image_key.split("/")
     locations_file = "{}/{}-{}.csv".format(
         keys[0],
@@ -23,12 +34,47 @@ def get_locations(image_key, config, random_sample=None, seed=None):
         else:
             return locations
     else:
-        y_key = "Nuclei_Location_Center_Y"
-        x_key = "Nuclei_Location_Center_X"
-        return pd.DataFrame(columns=[x_key, y_key])
+        return pd.DataFrame(columns=[X_KEY, Y_KEY])
+
+
+def get_full_image_locations(image_key, config, random_sample, seed):
+    cols = config["dataset"]["images"]["width"]
+    rows = config["dataset"]["images"]["height"]
+    coverage = config["dataset"]["locations"]["area_coverage"]
+    cols_margin = cols - int(cols * coverage)
+    rows_margin = rows - int(rows * coverage)
+ 
+    data = None
+    if coverage == 1.0:
+        data = [[rows/2, cols/2]]
+    else:
+        if random_sample is not None:
+            cols_pos = np.random.randint(low=-cols_margin/2, high=cols_margin/2, size=random_sample) + cols/2
+            rows_pos = np.random.randint(low=-rows_margin/2, high=rows_margin/2, size=random_sample) + rows/2
+            data = [[cols_pos[i], rows_pos[i]] for i in range(random_sample)]
+        elif random_sample is None:
+            cols_pos = [cols/2 - cols_margin/2, cols/2 - cols_margin/2, cols/2 + cols_margin/2, cols/2 + cols_margin/2, cols/2]
+            rows_pos = [rows/2 - rows_margin/2, rows/2 + rows_margin/2, rows/2 - rows_margin/2, rows/2 + rows_margin/2, rows/2]
+            data = [[cols_pos[i], rows_pos[i]] for i in range(5)]
+
+    return pd.DataFrame(data=data, columns=[X_KEY, Y_KEY])
+
 
 def prepare_boxes(batch, config):
-    locationsBatch = batch["locations"]
+    if config["dataset"]["locations"]["mode"] == "single_cells":
+        box_side = config["dataset"]["locations"]["box_size"]
+        return prepare_cropping_regions(batch, config, box_side, box_side)
+    elif config["dataset"]["locations"]["mode"] == "full_image":
+        cols = config["dataset"]["images"]["width"]
+        rows = config["dataset"]["images"]["height"]
+        coverage = config["dataset"]["locations"]["area_coverage"]
+        return prepare_cropping_regions(batch, config, int(cols * coverage), int(rows * coverage))
+    else:
+        return None
+
+
+def prepare_cropping_regions(batch, config, box_width, box_height):
+    locations_batch = batch["locations"]
     image_targets = batch["targets"]
     images = batch["images"]
     all_boxes = []
@@ -36,20 +82,19 @@ def prepare_boxes(batch, config):
     all_targets = [[] for i in range(len(image_targets[0]))]
     all_masks = []
     index = 0
-    y_key = "Nuclei_Location_Center_Y"
-    x_key = "Nuclei_Location_Center_X"
-    for locations in locationsBatch:
+
+    for locations in locations_batch:
         # Collect and normalize boxes between 0 and 1
         boxes = np.zeros((len(locations), 4), np.float32)
-        boxes[:,0] = locations[y_key] - config["dataset"]["locations"]["box_size"]/2
-        boxes[:,1] = locations[x_key] - config["dataset"]["locations"]["box_size"]/2
-        boxes[:,2] = locations[y_key] + config["dataset"]["locations"]["box_size"]/2
-        boxes[:,3] = locations[x_key] + config["dataset"]["locations"]["box_size"]/2
+        boxes[:,0] = locations[Y_KEY] - box_height/2
+        boxes[:,1] = locations[X_KEY] - box_width/2
+        boxes[:,2] = locations[Y_KEY] + box_height/2
+        boxes[:,3] = locations[X_KEY] + box_width/2
         boxes[:,[0,2]] /= config["dataset"]["images"]["height"]
         boxes[:,[1,3]] /= config["dataset"]["images"]["width"]
         # Create indicators for this set of boxes, belonging to the same image
         box_ind = index * np.ones((len(locations)), np.int32)
-        # Propage the same labels to all crops
+        # Propagate the same labels to all crops
         for i in range(len(image_targets[index])):
             all_targets[i].append(image_targets[index][i] * np.ones((len(locations)), np.int32))
         # Identify object mask for each crop
@@ -57,8 +102,8 @@ def prepare_boxes(batch, config):
         if config["dataset"]["locations"]["mask_objects"]:
             i = 0
             for lkey in locations.index:
-                y = int(locations.loc[lkey, y_key])
-                x = int(locations.loc[lkey, x_key])
+                y = int(locations.loc[lkey, Y_KEY])
+                x = int(locations.loc[lkey, X_KEY])
                 patch = images[index][max(y-5,0):y+5, max(x-5,0):x+5, -1]
                 if np.size(patch) > 0:
                     masks[i] = int(np.median(patch))

--- a/deepprofiler/imaging/boxes.py
+++ b/deepprofiler/imaging/boxes.py
@@ -41,10 +41,10 @@ def prepare_boxes(batch, config):
     for locations in locationsBatch:
         # Collect and normalize boxes between 0 and 1
         boxes = np.zeros((len(locations), 4), np.float32)
-        boxes[:,0] = locations[y_key] - config["train"]["sampling"]["box_size"]/2
-        boxes[:,1] = locations[x_key] - config["train"]["sampling"]["box_size"]/2
-        boxes[:,2] = locations[y_key] + config["train"]["sampling"]["box_size"]/2
-        boxes[:,3] = locations[x_key] + config["train"]["sampling"]["box_size"]/2
+        boxes[:,0] = locations[y_key] - config["dataset"]["locations"]["box_size"]/2
+        boxes[:,1] = locations[x_key] - config["dataset"]["locations"]["box_size"]/2
+        boxes[:,2] = locations[y_key] + config["dataset"]["locations"]["box_size"]/2
+        boxes[:,3] = locations[x_key] + config["dataset"]["locations"]["box_size"]/2
         boxes[:,[0,2]] /= config["dataset"]["images"]["height"]
         boxes[:,[1,3]] /= config["dataset"]["images"]["width"]
         # Create indicators for this set of boxes, belonging to the same image

--- a/deepprofiler/imaging/cropping.py
+++ b/deepprofiler/imaging/cropping.py
@@ -47,7 +47,7 @@ class CropGenerator(object):
         crop_channels = len(self.config["dataset"]["images"]["channels"])
 
         # Identify image and box sizes
-        box_size = self.config["train"]["sampling"]["box_size"]
+        box_size = self.config["dataset"]["locations"]["box_size"]
         img_width = self.config["dataset"]["images"]["width"]
         img_height = self.config["dataset"]["images"]["height"]
 

--- a/deepprofiler/imaging/cropping.py
+++ b/deepprofiler/imaging/cropping.py
@@ -39,7 +39,7 @@ class CropGenerator(object):
 
     def build_input_graph(self):
         # Identify number of channels
-        mask_objects = self.config["train"]["sampling"]["mask_objects"]
+        mask_objects = self.config["dataset"]["locations"]["mask_objects"]
         if mask_objects:
             img_channels = len(self.config["dataset"]["images"]["channels"]) + 1
         else:

--- a/plugins/crop_generators/repeat_channel_crop_generator.py
+++ b/plugins/crop_generators/repeat_channel_crop_generator.py
@@ -21,7 +21,7 @@ class SingleImageGeneratorClass(deepprofiler.imaging.cropping.SingleImageCropGen
 
     def __init__(self, config, dset):
         super().__init__(config, dset)
-        width = self.config["train"]["sampling"]["box_size"]
+        width = self.config["dataset"]["locations"]["box_size"]
         height = width
         channels = len(self.config["dataset"]["images"]["channels"])
         self.crop_ph = tf.placeholder(tf.float32, (None, width, height, channels))

--- a/plugins/models/autoencoder.py
+++ b/plugins/models/autoencoder.py
@@ -17,8 +17,8 @@ from deepprofiler.learning.model import DeepProfilerModel
 def define_model(config, dset):
     # Define input layer
     input_shape = (
-        config["train"]["sampling"]["box_size"],  # height
-        config["train"]["sampling"]["box_size"],  # width
+        config["dataset"]["locations"]["box_size"],  # height
+        config["dataset"]["locations"]["box_size"],  # width
         len(config["dataset"]["images"]["channels"])  # channels
     )
     input_image = keras.layers.Input(input_shape)

--- a/plugins/models/cnn.py
+++ b/plugins/models/cnn.py
@@ -17,8 +17,8 @@ from deepprofiler.learning.model import DeepProfilerModel
 def define_model(config, dset):
     # Define input layer
     input_shape = (
-        config["train"]["sampling"]["box_size"],  # height
-        config["train"]["sampling"]["box_size"],  # width
+        config["dataset"]["locations"]["box_size"],  # height
+        config["dataset"]["locations"]["box_size"],  # width
         len(config["dataset"]["images"]["channels"])  # channels
     )
     input_image = keras.layers.Input(input_shape)

--- a/plugins/models/inception_resnet_v2.py
+++ b/plugins/models/inception_resnet_v2.py
@@ -30,8 +30,8 @@ def define_model(config, dset):
     else:
         weights = None
         input_tensor = Input((
-            config["train"]["sampling"]["box_size"],  # height
-            config["train"]["sampling"]["box_size"],  # width
+            config["dataset"]["locations"]["box_size"],  # height
+            config["dataset"]["locations"]["box_size"],  # width
             len(config["dataset"]["images"]["channels"])  # channels
         ), name="input")
         base = inception_resnet_v2.InceptionResNetV2(

--- a/plugins/models/resnet.py
+++ b/plugins/models/resnet.py
@@ -43,8 +43,8 @@ class ModelClass(DeepProfilerModel):
     def define_model(self, config, dset):
         # 1. Create ResNet architecture to extract features
         input_shape = (
-            config["train"]["sampling"]["box_size"],  # height
-            config["train"]["sampling"]["box_size"],  # width
+            config["dataset"]["locations"]["box_size"],  # height
+            config["dataset"]["locations"]["box_size"],  # width
             len(config["dataset"]["images"][
                 "channels"])  # channels
         )

--- a/tests/deepprofiler/imaging/test_cropping.py
+++ b/tests/deepprofiler/imaging/test_cropping.py
@@ -70,8 +70,8 @@ def test_crop_generator_build_input_graph(crop_generator):
     assert crop_generator.input_variables["mask_ind_ph"].get_shape().as_list() == [None]
     assert len(crop_generator.input_variables["labeled_crops"]) == 1 + len(crop_generator.dset.targets)
     assert crop_generator.input_variables["labeled_crops"][0].get_shape().as_list() == [None,
-                                                                                        crop_generator.config["train"]["sampling"]["box_size"],
-                                                                                        crop_generator.config["train"]["sampling"]["box_size"],
+                                                                                        crop_generator.config["dataset"]["locations"]["box_size"],
+                                                                                        crop_generator.config["dataset"]["locations"]["box_size"],
                                                                                         len(crop_generator.config["dataset"]["images"]["channels"])]
     for target in crop_generator.input_variables["labeled_crops"][1:]:
         assert target.get_shape().as_list() == [None]
@@ -84,8 +84,8 @@ def test_crop_generator_build_augmentation_graph(crop_generator):
         generated_shape = image_batch.shape #get_shape().as_list() 
 
     generated_shape == [None,
-                        crop_generator.config["train"]["sampling"]["box_size"],
-                        crop_generator.config["train"]["sampling"]["box_size"],
+                        crop_generator.config["dataset"]["locations"]["box_size"],
+                        crop_generator.config["dataset"]["locations"]["box_size"],
                         len(crop_generator.config["dataset"]["images"]["channels"])]
 
 def test_crop_generator_start(prepared_crop_generator):  # includes test for training queues
@@ -104,8 +104,8 @@ def test_crop_generator_sample_batch(prepared_crop_generator):
         prepared_crop_generator.ready_to_sample = True
         data = prepared_crop_generator.sample_batch(pool_index)
         assert np.array(data[0]).shape == (prepared_crop_generator.config["train"]["model"]["params"]["batch_size"],
-                                       prepared_crop_generator.config["train"]["sampling"]["box_size"],
-                                       prepared_crop_generator.config["train"]["sampling"]["box_size"],
+                                       prepared_crop_generator.config["dataset"]["locations"]["box_size"],
+                                       prepared_crop_generator.config["dataset"]["locations"]["box_size"],
                                        len(prepared_crop_generator.config["dataset"]["images"]["channels"]))
         assert data[1].shape == (prepared_crop_generator.config["train"]["model"]["params"]["batch_size"], prepared_crop_generator.dset.targets[0].shape[1])
         assert data[2] == 0
@@ -121,8 +121,8 @@ def test_crop_generator_generate(prepared_crop_generator):
         for i in range(test_steps):
             data = next(generator)
             assert np.array(data[0]).shape == (prepared_crop_generator.config["train"]["model"]["params"]["batch_size"],
-                                           prepared_crop_generator.config["train"]["sampling"]["box_size"],
-                                           prepared_crop_generator.config["train"]["sampling"]["box_size"],
+                                           prepared_crop_generator.config["dataset"]["locations"]["box_size"],
+                                           prepared_crop_generator.config["dataset"]["locations"]["box_size"],
                                            len(prepared_crop_generator.config["dataset"]["images"]["channels"]))
             assert len(data[1]) == len(prepared_crop_generator.dset.targets)
             for item in data[1]:
@@ -151,8 +151,8 @@ def test_single_image_crop_generator_start(single_image_crop_generator):
         assert hasattr(single_image_crop_generator, "input_variables")
         #assert single_image_crop_generator.angles.get_shape().as_list() == [None]
         #assert single_image_crop_generator.aligned_labeled[0].get_shape().as_list() == [None,
-        #                                                                                single_image_crop_generator.config["train"]["sampling"]["box_size"],
-        #                                                                                single_image_crop_generator.config["train"]["sampling"]["box_size"],
+        #                                                                                single_image_crop_generator.config["dataset"]["locations"]["box_size"],
+        #                                                                                single_image_crop_generator.config["dataset"]["locations"]["box_size"],
         #                                                                                len(single_image_crop_generator.config["dataset"]["images"]["channels"])]
         #assert single_image_crop_generator.aligned_labeled[1].get_shape().as_list() == [None]
 
@@ -179,8 +179,8 @@ def test_single_image_crop_generator_prepare_image(single_image_crop_generator, 
         assert num_crops == 10
         assert single_image_crop_generator.batch_size == single_image_crop_generator.config["train"]["validation"]["batch_size"]
         assert np.array(single_image_crop_generator.image_pool).shape == (10,
-                                                                      single_image_crop_generator.config["train"]["sampling"]["box_size"],
-                                                                      single_image_crop_generator.config["train"]["sampling"]["box_size"],
+                                                                      single_image_crop_generator.config["dataset"]["locations"]["box_size"],
+                                                                      single_image_crop_generator.config["dataset"]["locations"]["box_size"],
                                                                       len(single_image_crop_generator.config["dataset"]["images"]["channels"]))
         assert np.array(single_image_crop_generator.label_pool).shape == (10, num_classes)
 
@@ -206,8 +206,8 @@ def test_single_image_crop_generator_generate(single_image_crop_generator, make_
         num_crops = single_image_crop_generator.prepare_image(sess, image, meta)
         for i, item in enumerate(single_image_crop_generator.generate(sess)):
             assert np.array(item[0]).shape == (10,
-                                           single_image_crop_generator.config["train"]["sampling"]["box_size"],
-                                           single_image_crop_generator.config["train"]["sampling"]["box_size"],
+                                           single_image_crop_generator.config["dataset"]["locations"]["box_size"],
+                                           single_image_crop_generator.config["dataset"]["locations"]["box_size"],
                                            len(single_image_crop_generator.config["dataset"]["images"]["channels"]))
             assert np.array(item[1]).shape == (10, num_classes)
             assert i == 0

--- a/tests/files/config/test.json
+++ b/tests/files/config/test.json
@@ -14,6 +14,12 @@
             "width": 128,
             "height": 128,
             "bits": 16
+        },
+        "locations": {
+            "mode": "single_cells",
+            "box_size": 32,
+            "area_coverage": 1.0,
+            "mask_objects": false
         }
     },
     "prepare": {
@@ -56,8 +62,6 @@
         },
         "sampling": {
             "factor": 1.0,
-            "box_size": 16,
-            "mask_objects": false,
             "queue_size": 10,
             "workers": 2,
             "alpha": 0.2

--- a/tests/files/config/test.json
+++ b/tests/files/config/test.json
@@ -17,7 +17,7 @@
         },
         "locations": {
             "mode": "single_cells",
-            "box_size": 32,
+            "box_size": 16,
             "area_coverage": 1.0,
             "mask_objects": false
         }

--- a/tests/plugins/crop_generators/test_mixup_crop_generator.py
+++ b/tests/plugins/crop_generators/test_mixup_crop_generator.py
@@ -139,8 +139,8 @@ def test_generate(prepared_crop_generator):
     for i in range(test_steps):
         data = next(generator)
         assert np.array(data[0]).shape == (prepared_crop_generator.config["train"]["model"]["params"]["batch_size"],
-                                           prepared_crop_generator.config["train"]["sampling"]["box_size"],
-                                           prepared_crop_generator.config["train"]["sampling"]["box_size"],
+                                           prepared_crop_generator.config["dataset"]["locations"]["box_size"],
+                                           prepared_crop_generator.config["dataset"]["locations"]["box_size"],
                                            len(prepared_crop_generator.config["dataset"]["images"]["channels"]))
         assert data[1].shape == (prepared_crop_generator.config["train"]["model"]["params"]["batch_size"], prepared_crop_generator.dset.targets[0].shape[1])
     prepared_crop_generator.stop(sess)

--- a/tests/plugins/models/test_densenet.py
+++ b/tests/plugins/models/test_densenet.py
@@ -21,7 +21,7 @@ def val_generator():
 def test_init(config, dataset, generator, val_generator):
     config["train"]["model"]["name"] = "densenet"
     config["train"]["model"]["params"]["conv_blocks"] = 121
-    config["train"]["sampling"]["box_size"] = 32
+    config["dataset"]["locations"]["box_size"] = 32
     config["train"]["model"]["params"]["pooling"] = 'avg'
     dpmodel = plugins.models.densenet.ModelClass(config, dataset, generator, val_generator)
     model, optimizer, loss = plugins.models.densenet.ModelClass.define_model(dpmodel, config, dataset)


### PR DESCRIPTION
Implementation of image analysis without single cell locations. The generation of single cells has been extended to allow getting image regions without specifying exact locations. These image regions can cover a specified area of the original image (100%, 75%, or something else defined by the user), making it a flexible tool for image classification.

Covering a smaller area of the original image is more data efficient because multiple crops can be extracted from the same image to train models. Using the full image can result in overfitting to entire fields of view, while using slightly smaller crops can serve as an augmentation strategy. If the covering area is smaller than the original image, the new implementation will generate 5 image regions during testing: the 4 corners plus the central crop. This applies for validation and profiling experiments.

In addition, the crops are also resized to the desired box size as if they were single cells. This allows networks to be efficient in GPU memory given that full images don't need to be processed at full resolution. This size can be defined by the user.

The following experiment reports a result obtained with the BBBC021 dataset. The configuration was set with image regions that cover 75% of the original image and are scaled down to 256x256 pixels. https://www.comet.ml/jccaicedo/bbbc021/47852a1451d5489e824b92c3443c426a

 