### PR TITLE
Remove compression metadata + metadata param

### DIFF
--- a/deepprofiler/dataset/image_dataset.py
+++ b/deepprofiler/dataset/image_dataset.py
@@ -198,6 +198,8 @@ class ImageDataset():
 def read_dataset(config):
     # Read metadata and split dataset in training and validation
     metadata = deepprofiler.dataset.metadata.Metadata(config["paths"]["index"], dtype=None)
+    if config["prepare"]["compression"]["implement"]:
+        metadata.data.replace({'.tiff': '.png', '.tif': '.png'}, inplace=True, regex=True)
 
     # Add outlines if specified
     outlines = None

--- a/deepprofiler/dataset/indexing.py
+++ b/deepprofiler/dataset/indexing.py
@@ -1,17 +1,5 @@
 import pandas as pd
 
-import deepprofiler.dataset.metadata
-
-def write_compression_index(config):
-    metadata = deepprofiler.dataset.metadata.Metadata(config["paths"]["index"], dtype=None)
-    new_index = metadata.data
-    for ch in config["dataset"]["images"]["channels"]:
-        new_index[ch] = new_index[ch].str.split("/").str[-1]
-        png_path = lambda x: "/" + x.replace("."+config["dataset"]["images"]["file_format"], ".png")
-        new_index[ch] = new_index["Metadata_Plate"].astype(str) + new_index[ch].map(png_path)
-    new_index.to_csv(config["paths"]["compressed_metadata"] + "/compressed.csv")
-
-
 ## Split a metadata file in a number of parts
 def split_index(config, parts):
     index = pd.read_csv(config["paths"]["metadata"] + "/index.csv")

--- a/tests/deepprofiler/dataset/test_indexing.py
+++ b/tests/deepprofiler/dataset/test_indexing.py
@@ -5,17 +5,11 @@ import pandas as pd
 import os
 
 
-def test_write_compression_index(config, metadata, dataset, make_struct):
-    deepprofiler.dataset.indexing.write_compression_index(config)
-    test_output = pd.read_csv(config["paths"]["compressed_metadata"]+"/compressed.csv", index_col=0)
-    assert test_output.shape == (12,8)
-
 def test_split_index(config, metadata, dataset):
     test_parts = 3
     test_paths = [config["paths"]["metadata"]+"/index-000.csv",
                   config["paths"]["metadata"]+"/index-001.csv",
                   config["paths"]["metadata"]+"/index-002.csv"]
-    deepprofiler.dataset.indexing.write_compression_index(config)
     deepprofiler.dataset.indexing.split_index(config, test_parts)   
     assert os.path.exists(test_paths[0]) == True
     assert os.path.exists(test_paths[1]) == True


### PR DESCRIPTION
I tried to compress\train\profile and it seems to work. Tests are also fine.
We still have additional metadata for sampled single-cells.