### PR TITLE
Switch augmentations on and off in the config.

### DIFF
--- a/plugins/models/efficientnet.py
+++ b/plugins/models/efficientnet.py
@@ -5,7 +5,8 @@ import efficientnet.tfkeras as efn
 from deepprofiler.learning.model import DeepProfilerModel
 from deepprofiler.imaging.augmentations import AugmentationLayer
 
-tf.compat.v1.disable_v2_behavior()
+#tf.compat.v1.disable_v2_behavior()
+#tf.config.run_functions_eagerly(False)
 
 
 class ModelClass(DeepProfilerModel):
@@ -33,7 +34,7 @@ class ModelClass(DeepProfilerModel):
         error_msg = str(num_layers) + " conv_blocks not in " + SM
         assert num_layers in supported_models.keys(), error_msg
 
-        if self.is_training and weights is None:
+        if self.is_training and weights is None and self.config["train"]['model'].get('augmentations') is True:
             input_image = AugmentationLayer()(input_image)
 
         model = supported_models[num_layers](
@@ -53,8 +54,7 @@ class ModelClass(DeepProfilerModel):
 
         optimizer = tf.compat.v1.keras.optimizers.SGD(lr=config["train"]["model"]["params"]["learning_rate"], momentum=0.9,
                                          nesterov=True)
-        #loss_func = "categorical_crossentropy"
-        loss_func = tf.compat.v1.keras.losses.CategoricalCrossentropy(label_smoothing=0.2)
+        loss_func = tf.compat.v1.keras.losses.CategoricalCrossentropy(label_smoothing=0.2)  # TODO:parameterize?
 
         if self.is_training is False and "use_pretrained_input_size" in config["profile"].keys():
             input_tensor = tf.compat.v1.keras.layers.Input(
@@ -65,8 +65,7 @@ class ModelClass(DeepProfilerModel):
             input_shape = (
                 config["dataset"]["locations"]["box_size"],  # height
                 config["dataset"]["locations"]["box_size"],  # width
-                len(config["dataset"]["images"][
-                        "channels"])  # channels
+                len(config["dataset"]["images"]["channels"])  # channels
             )
             input_image = tf.compat.v1.keras.layers.Input(input_shape)
             model = self.get_model(config, input_image=input_image)
@@ -74,12 +73,11 @@ class ModelClass(DeepProfilerModel):
             # 2. Create an output embedding for each target
             class_outputs = []
 
-            y = tf.compat.v1.keras.layers.Dense(config["num_classes"], activation="softmax", name="ClassProb")(features)
+            y = tf.compat.v1.keras.layers.Dense(len(dset.targets[0].values), activation="softmax", name="ClassProb")(features)
             class_outputs.append(y)
 
             # 4. Create and compile model
             model = tf.compat.v1.keras.models.Model(inputs=input_image, outputs=class_outputs)
-
 
             ## Added weight decay following tricks reported in:
             ## https://github.com/keras-team/keras/issues/2717
@@ -88,16 +86,19 @@ class ModelClass(DeepProfilerModel):
                 if hasattr(layer, "kernel_regularizer"):
                     setattr(layer, "kernel_regularizer", regularizer)
 
-            model = tf.compat.v1.keras.models.model_from_json(
-                model.to_json(),
-                {'AugmentationLayer': AugmentationLayer}
-            )
+            if self.config["train"]["model"].get("augmentations") is True:
+                model = tf.compat.v1.keras.models.model_from_json(
+                    model.to_json(),
+                    {'AugmentationLayer': AugmentationLayer}
+                )
+            else:
+                model = tf.compat.v1.keras.models.model_from_json(model.to_json())
 
         return model, optimizer, loss_func
 
     def copy_pretrained_weights(self):
         base_model = self.get_model(self.config, weights="imagenet")
-        lshift = self.is_training  # Shift one layer to accommodate the AugmentationLayer
+        lshift = self.feature_model.layers[1].name == 'augmentation_layer'  # Shift one layer to accommodate the AugmentationLayer
 
         # => Transfer all weights except conv1.1
         total_layers = len(base_model.layers)
@@ -114,7 +115,7 @@ class ModelClass(DeepProfilerModel):
 
         for i in range(new_weights.shape[2]):
             j = i % available_channels
-            new_weights[:,:,i,:] = weights[0][:,:,j,:]
+            new_weights[:, :, i, :] = weights[0][:, :, j, :]
 
         weights_array = [new_weights]
         if len(weights) > 1: 

--- a/tests/files/config/test.json
+++ b/tests/files/config/test.json
@@ -43,6 +43,7 @@
         },
         "model": {
             "name": "cnn",
+            "augmentations": false,
             "crop_generator": "crop_generator",
             "metrics": ["accuracy"],
             "epochs": 5,


### PR DESCRIPTION
The PR solves https://github.com/cytomining/DeepProfiler/issues/281. 
The configuration parameter is `config['train']['model']['augmentations']`.
If the parameter is not in the config, the default behavior is to not use the augmentations. 