### PR TITLE
Fix the condition for mask export.

### DIFF
--- a/deepprofiler/dataset/sampling.py
+++ b/deepprofiler/dataset/sampling.py
@@ -20,7 +20,10 @@ class SingleCellSampler(deepprofiler.imaging.cropping.CropGenerator):
         # Define input data batches
         with tf.compat.v1.variable_scope("train_inputs"):
             self.config["train"]["model"]["params"]["batch_size"] = self.config["train"]["validation"]["batch_size"]
-            self.build_input_graph(export_masks=True)
+            if self.config["prepare"].get("outlines") is not None:
+                self.build_input_graph(export_masks=True)
+            else:
+                self.build_input_graph(export_masks=False)
 
     def process_batch(self, batch):
         for i in range(len(batch["keys"])):


### PR DESCRIPTION
This branch solves #326, when export did not work properly without masks.
The current behaviour is the following: 
if `outlines` field and `mask_objects:true` are both in the config - then the cells are exported with masks
if no `outlines` field and `mask_objects:false` in the config - the cells are exported without masks correctly
if no `outlines` field and `mask_objects:true` in the config - DeepProfiler will crash.

I was wondering if we want the following functionality later: export masked cells right away without saving the mask itself. 