### PR TITLE
Add the option to have an image path inside index file

### DIFF
--- a/deepprofiler/dataset/image_dataset.py
+++ b/deepprofiler/dataset/image_dataset.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import os
 
 import deepprofiler.dataset.pixels
 import deepprofiler.dataset.utils
@@ -61,7 +62,9 @@ class ImageDataset():
 
     def get_image_paths(self, r):
         key = self.keyGen(r)
-        image = [self.root + "/" + r[ch] for ch in self.channels]
+        list_images = [r[ch] for ch in self.channels]
+        paths = [(os.path.split(r[ch]))[0] for ch in self.channels]
+        image = [list_images[ch] if os.path.isdir(paths[ch]) else self.root + "/" + list_images[ch] for ch in range(len(paths))]
         outlines = self.outlines
         if outlines is not None:
             outlines = self.outlines + r["Outlines"]


### PR DESCRIPTION
This PR adds the possibility for the user to give a full path to the image file inside the index.csv file. It's just checking if the FileName is a path; if it's a path, it won't add the root to the FileName. 

The user may want to give a full path to the image file instead of moving the images to inputs/images. DeepProfiler expects to have the images inside "inputs/images", and it always adds the root path to the filenames. 

Mostly for RunDeepProfiler ([discussion](https://github.com/CellProfiler/CellProfiler-plugins/discussions/183) and [PR](https://github.com/CellProfiler/CellProfiler-plugins/pull/182)) to work on CellProfiler we need to have this function so we don't need to move the images to inputs/images and grab it from the user's inputs. 

I've tested this also by giving the inputs as DeepProfiler usually expects (index.csv only having "Plate/FileName") and it worked fine. 