### PR TITLE
Use correct min/max stretching, and guard against flat images

### DIFF
--- a/deepprofiler/imaging/cropping.py
+++ b/deepprofiler/imaging/cropping.py
@@ -332,6 +332,15 @@ class SingleImageCropGenerator(CropGenerator):
             self.input_variables["mask_ind_ph"]: mask_ind
         }
 
+        # check that all boxes overlap the image
+        ymins = boxes[:, [0, 2]].min(axis=1)
+        ymaxs = boxes[:, [0, 2]].max(axis=1)
+        xmins = boxes[:, [1, 3]].min(axis=1)
+        xmaxs = boxes[:, [1, 3]].max(axis=1)
+        if (np.any(ymins > 1) or np.any(xmins > 1) or
+            np.any(ymaxs < 0) or np.any(ymaxs < 0)):
+            print("WARNING: Some cell boxes are entirely outside the image")
+
         for i in range(num_targets):
             tname = "target_" + str(i)
             feed_dict[self.input_variables["targets_phs"][tname]] = targets[i]

--- a/deepprofiler/imaging/cropping.py
+++ b/deepprofiler/imaging/cropping.py
@@ -30,7 +30,7 @@ def crop_graph(image_ph, boxes_ph, box_ind_ph, mask_ind_ph, box_size, mask_boxes
         #crops = (crops - mean)/std
         mini = tf.math.reduce_min(crops, axis=[1, 2], keepdims=True)
         maxi = tf.math.reduce_max(crops, axis=[1, 2], keepdims=True)
-        crops = (crops - mini) / maxi
+        crops = (crops - mini) / (maxi - mini + tf.keras.backend.epsilon())
 
         if export_masks:
             crops = tf.concat((crops[:, :, :, 0:-1], tf.expand_dims(masks, axis=-1)), axis=3)

--- a/deepprofiler/learning/profiling.py
+++ b/deepprofiler/learning/profiling.py
@@ -82,6 +82,16 @@ class Profile(object):
         if total_crops == 0:
             print("No cells to profile:", output_file)
             return
+
+        # check image size matches config
+        if (self.config["dataset"]["images"]["width"] != image_array.shape[1] or
+            self.config["dataset"]["images"]["height"] != image_array.shape[0]):
+            config_shape = (self.config["dataset"]["images"]["width"],
+                            self.config["dataset"]["images"]["height"])
+            im_shape = (image_array.shape[1], image_array.shape[0])
+            raise ValueError("Loaded image shape WxH " + str(im_shape) +
+                             " != configured image shape WxH " + str(config_shape))
+
         repeats = self.config["train"]["model"]["crop_generator"] in ["repeat_channel_crop_generator", "individual_channel_cropgen"]
         
         # Extract features


### PR DESCRIPTION
The min/max stretching was using (im - min) / max, instead of (im - min) / (max - min).  This change fixes that stretch, and also adds a small epsilon to guard against NaNs when max == min.